### PR TITLE
Increase Timeout to 7 Seconds

### DIFF
--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -10,7 +10,7 @@ from utils import utils
 # Measure a site's HTTP behavior using DHS NCATS' pshtt tool.
 
 # Network timeout for each internal pshtt HTTP request.
-pshtt_timeout = 5
+pshtt_timeout = 7
 
 # Default to a custom user agent that can be overridden via an environment
 # variable


### PR DESCRIPTION
## 🗣 Description ##

Goal: ensure valid HTTPS endpoints have time to respond by increasing the timeout.

## 💭 Motivation and context ##

Some agencies have websites/services that take just a hair longer than the 5 second timeout to respond. Please increase ever so slightly to ensure we aren't reporting false positives in the HTTPS Reports (e.g. Domain Supports HTTPS = false, when really it is true but just taking a little bit to respond).

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).