### PR TITLE
Update logging library syntax to get rid of a warning

### DIFF
--- a/scan
+++ b/scan
@@ -420,7 +420,7 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta, pr
             meta['lambda']['retries'] = meta['lambda']['retries'] + 1
             logging.info('Attempting retry number {} for {}'.format(meta['lambda']['retries'], domain))
         else:
-            logging.warn('No more retries for {}'.format(domain))
+            logging.warning('No more retries for {}'.format(domain))
             return previousData
 
     task_prefix = "task_"  # default, maybe make optional later


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates some Python `logging` library syntax to get rid of a warning.

## 💭 Motivation and context ##

`logging.warn()` has been deprecated in favor of `logging.warning()`.

## 🧪 Testing ##

I ran a few test scans with these changes and verified that they worked fine.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
