### PR TITLE
Fix bugs from the switch to the `publicsuffixlist` package

### DIFF
--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -314,6 +314,9 @@ def load_suffix_list(cache_dir="./cache"):
 
     cached_psl = cache_single("public-suffix-list.txt", cache_dir=cache_dir)
 
+    # make sure the cache directory is present
+    mkdir_p(os.path.dirname(cached_psl))
+
     # File does not exist, download current list and cache it at given location.
     if not os.path.exists(cached_psl):
         logging.debug("Downloading the Public Suffix List...")

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -322,7 +322,7 @@ def load_suffix_list(cache_dir="./cache"):
         except Exception as err:
             logging.warning("Unable to download the Public Suffix List...")
             logging.debug("{}".format(err))
-            return None, None
+            return None
 
 
     logging.debug("Using cached Public Suffix List...")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -513,6 +513,9 @@ def load_suffix_list(cache_dir="./cache"):
 
     cached_psl = cache_single("public-suffix-list.txt", cache_dir=cache_dir)
 
+    # make sure the cache directory is present
+    mkdir_p(os.path.dirname(cached_psl))
+
     # File does not exist, download current list and cache it at given location.
     if not os.path.exists(cached_psl):
         logging.debug("Downloading the Public Suffix List...")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -521,7 +521,7 @@ def load_suffix_list(cache_dir="./cache"):
         except Exception as err:
             logging.warning("Unable to download the Public Suffix List...")
             logging.debug("{}".format(err))
-            return None, None
+            return None
 
 
     logging.debug("Using cached Public Suffix List...")


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Thie pull request fixes two issues with using the new Public Suffix List package we switched to in #2.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

These two bugs (wrong return value and missing cache directory) cause breaking behavior.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this change locally and in an updated [cisagov/scanner](https://github.com/cisagov/scanner) Docker image.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
