### PR TITLE
Pin pshtt to the latest version we support

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,10 @@
 builtwith>=1.3.4
 
 # pshtt
-pshtt>=0.6.10
+#
+# Newer versions of pshtt will support sslyze>=3, which we are not yet
+# ready to support.
+pshtt==0.6.10
 
 # trustymail
 trustymail>=0.8.1


### PR DESCRIPTION
## 🗣 Description ##

This pull request pins pshtt to the latest version as of today.

## 💭 Motivation and context ##

Newer versions of pshtt will support sslyze>=3, which we are not yet ready to support.  See cisagov/pshtt#214 for more details.

## 🧪 Testing ##

pshtt 0.6.10 is the version we have been using for eons.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).