### PR TITLE
Get rid of invalid escape sequence Python warnings, tighten `strip_wildcard` regex

### DIFF
--- a/gather
+++ b/gather
@@ -20,7 +20,7 @@ strip_www = re.compile(r"^www\.")
 
 # Applied to all domains.
 strip_protocol = re.compile(r"^https?://")
-strip_wildcard = re.compile(r"^(\*.)+")
+strip_wildcard = re.compile(r"^(\*\.)+")
 strip_redacted = re.compile(r"^(\?\.)+")
 
 

--- a/gather
+++ b/gather
@@ -16,12 +16,12 @@ start_time = utils.local_now()
 start_command = str.join(" ", sys.argv)
 
 # Applied if --ignore-www is enabled.
-strip_www = re.compile("^www\.")
+strip_www = re.compile(r"^www\.")
 
 # Applied to all domains.
-strip_protocol = re.compile("^https?://")
-strip_wildcard = re.compile("^(\*.)+")
-strip_redacted = re.compile("^(\?\.)+")
+strip_protocol = re.compile(r"^https?://")
+strip_wildcard = re.compile(r"^(\*.)+")
+strip_redacted = re.compile(r"^(\?\.)+")
 
 
 def run(options=None, cache_dir="./cache", results_dir="./results"):


### PR DESCRIPTION
## 🗣 Description ##

This pull request gets rid of some "invalid escape sequence" Python warnings by using raw strings for regexes.  It also adds a missing backslash escape to the `strip_wildcard` regex.

## 💭 Motivation and context ##

- Resolves #7.
- In changing the regexes to be raw strings I noticed that the `strip_wildcard` regex was not actually matching only what was intended.  In practice it is unlikely that anything unexpected was actually being matched, but it makes sense to go ahead and close that door by tightening the regex.

## 🧪 Testing ##

I built a new [cisagov/gatherer](https://github.com/cisagov/gatherer) Docker image with these changes and verified that it functioned as expected.  See cisagov/gatherer#108 for more details.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).